### PR TITLE
Player redirect on "big" actions

### DIFF
--- a/src/main/java/dev/onebiteaidan/worldshop/GUI/Screens/ViewCompletedTradesScreen.java
+++ b/src/main/java/dev/onebiteaidan/worldshop/GUI/Screens/ViewCompletedTradesScreen.java
@@ -116,7 +116,8 @@ public class ViewCompletedTradesScreen extends PageableMenu {
                                 player.sendMessage("Added your items to your inventory!");
                                 // Mark pickup as complete
                                 WorldShop.getStoreManager().withdrawPickup(pickupID);
-                                player.closeInventory();
+                                // Keeps player on the same screen to collect more pickups
+                                WorldShop.getMenuManager().openMenu(player, new ViewCompletedTradesScreen(player));
                             } else {
                                 player.sendMessage("Make room in your inventory for the item!");
                             }


### PR DESCRIPTION
- fix: Players now stay in the completed trades menu when retrieving items from completed trade.